### PR TITLE
Renamed p_interactor_session_agg_cpu_usage table to p_interactor_session

### DIFF
--- a/full_install.sql
+++ b/full_install.sql
@@ -131,8 +131,8 @@ drop table plainlogs_old;
 
 \i p_interactor_cpu_usage_report.sql
 \i p_processinfo.sql
-\i p_interactor_session_agg_cpu_usage.sql
-\i load_p_interactor_session_agg_cpu_usage.sql
+\i p_interactor_session.sql
+\i load_p_interactor_session.sql
 
 CREATE INDEX p_cpu_usage_report_cpu_usage_vizql_session_idx ON p_cpu_usage_report USING btree (cpu_usage_vizql_session)
 where cpu_usage_process_name in ('vizqlserver', 'dataserver', 'tabprotosrv', 'tdeserver');

--- a/migrations/v1.1.17.2/!install-up.sql
+++ b/migrations/v1.1.17.2/!install-up.sql
@@ -1,0 +1,41 @@
+\set ON_ERROR_STOP on
+set search_path = '#schema_name#';
+set role palette_palette_updater;
+
+select 
+		-- 4 is the number of columns that are additional columns in the p_cpu_usage_report table
+		case when cnt_repo = cnt_cpu_usage_report - 4
+			then 'Repository check OK. (There are no new columns for p_cpu_usage_report table)'
+		else
+			-- Division by zero on purpose, so that we can exit from this install script.
+			(1 / 0)::varchar
+		end as chk
+from
+(select count(1) as cnt_repo
+from
+	information_schema.columns c
+where	
+	c.table_name in ('h_sites', 'h_projects', 'h_workbooks', 'h_users', 'h_system_users')
+	and c.table_schema = '#schema_name#'
+) a
+,
+(select count(1) as cnt_cpu_usage_report
+from
+	information_schema.columns c
+where	
+	c.table_name = 'p_cpu_usage_report'
+	and c.table_schema = '#schema_name#'
+	and 
+	(c.column_name like 'site\_%'	 
+	 or c.column_name like 'project\_%'
+	 or c.column_name like 'workbook\_%'	 
+	 or c.column_name like 'publisher_user\_%'
+	 or c.column_name like 'publisher_s_user\_%'	 
+	 )
+) b
+;
+
+alter table p_interactor_session_agg_cpu_usage rename to p_interactor_session;
+\i 001-up-load_p_interactor_session.sql
+
+insert into db_version_meta(version_number) values ('v1.1.17.2');

--- a/migrations/v1.1.17.2/001-up-load_p_interactor_session.sql
+++ b/migrations/v1.1.17.2/001-up-load_p_interactor_session.sql
@@ -1,0 +1,97 @@
+CREATE or replace function load_p_interactor_session(p_schema_name text) returns bigint
+AS $$
+declare
+	v_sql text;
+	v_num_inserted bigint;	
+	v_max_ts_date_p_interactor_session text;
+	v_sql_cur text;
+BEGIN	
+
+		v_sql_cur := 'select to_char(coalesce(max(session_start_ts)::date, date''1001-01-01''), ''yyyy-mm-dd'') from #schema_name#.p_interactor_session';
+		v_sql_cur := replace(v_sql_cur, '#schema_name#', p_schema_name);		
+		execute v_sql_cur into v_max_ts_date_p_interactor_session;
+		v_max_ts_date_p_interactor_session := 'date''' || v_max_ts_date_p_interactor_session || '''';
+				
+		v_sql_cur := 'delete from #schema_name#.p_interactor_session where session_start_ts::date >= #max_ts_date_p_interactor_session#';
+		v_sql_cur := replace(v_sql_cur, '#schema_name#', p_schema_name);		
+		v_sql_cur := replace(v_sql_cur, '#max_ts_date_p_interactor_session#', v_max_ts_date_p_interactor_session);				
+
+		raise notice 'I: %', v_sql_cur;
+		execute v_sql_cur;
+
+		v_sql := 'INSERT INTO #schema_name#.p_interactor_session
+		(
+			vizql_session, 
+			process_name,
+			host_name,
+			cpu_time_consumption_seconds,
+			session_start_ts,
+			session_end_ts,
+			session_duration,
+			publisher_friendly_name_id,
+			publisher_user_name_id,
+			interactor_friendly_name_id,
+			interactor_user_name_id,
+			site_name_id,
+			project_name_id,
+			workbook_name_id,
+			workbook_revision,
+			http_user_agent,
+			num_fatals,
+			num_errors,
+			num_warnings
+		)
+		SELECT  
+		        cpu_usage_parent_vizql_session AS vizql_session,
+		        cpu_usage_process_name AS process_name,
+		        MIN(cpu_usage_host_name) AS host_name,
+		        SUM(cpu_usage_cpu_time_consumption_seconds) AS cpu_time_consumption_seconds,
+		        MIN(session_start_ts) AS session_start_ts,
+		        MIN(session_end_ts) AS session_end_ts,
+		        MIN(session_end_ts) - MIN(session_start_ts) AS session_duration,
+		        MIN(publisher_s_user_friendly_name) || '' ('' || MIN(publisher_s_user_id) || '')'' AS publisher_friendly_name_id,
+		        MIN(publisher_s_user_name) || '' ('' || MIN(publisher_s_user_id) || '')'' AS publisher_user_name_id,
+		        MIN(interactor_s_user_friendly_name) || '' ('' || MIN(interactor_s_user_id) || '')'' AS interactor_friendly_name_id,
+		        MIN(interactor_s_user_name) || '' ('' || MIN(interactor_s_user_id) || '')'' AS interactor_user_name_id,
+		        MIN(site_name_id) AS site_name_id,
+		        MIN(project_name_id) AS project_name_id,
+		        MIN(workbook_name_id) AS workbook_name_id,
+		        MIN(workbook_revision) AS workbook_revision,
+			MIN(http_user_agent) AS http_user_agent,
+		        MIN(num_fatal) AS num_fatal,
+		        MIN(num_error) AS num_error,
+		        MIN(num_warn) AS num_warn
+		FROM    
+		        #schema_name#.p_cpu_usage_report pcur
+		        LEFT OUTER JOIN (SELECT vizql_session, MIN(http_user_agent) AS http_user_agent FROM #schema_name#.p_http_requests GROUP BY vizql_session) user_agents
+		                ON (pcur.cpu_usage_parent_vizql_session = user_agents.vizql_session)
+		        LEFT OUTER JOIN (
+		                SELECT  
+		                        parent_vizql_session AS vizql_session,
+		                        process_name, 
+		                        SUM(CASE WHEN sev = ''fatal'' THEN 1 ELSE 0 END) num_fatal,
+		                        SUM(CASE WHEN sev = ''error'' THEN 1 ELSE 0 END) num_error,
+		                        SUM(CASE WHEN sev = ''warn'' THEN 1 ELSE 0 END) num_warn
+		                FROM 
+		                        #schema_name#.p_serverlogs
+		                WHERE ts >= #max_ts_date_p_interactor_session# - 1
+		                GROUP BY parent_vizql_session, process_name
+		        ) num_loglevels
+		                ON (pcur.cpu_usage_parent_vizql_session = num_loglevels.vizql_session AND pcur.cpu_usage_process_name = num_loglevels.process_name)
+		WHERE cpu_usage_ts_rounded_15_secs >= #max_ts_date_p_interactor_session#
+		        AND cpu_usage_parent_vizql_session IS NOT NULL
+		GROUP BY cpu_usage_parent_vizql_session, cpu_usage_process_name;
+		';
+
+
+			v_sql := replace(v_sql, '#schema_name#', p_schema_name);			
+			v_sql := replace(v_sql, '#max_ts_date_p_interactor_session#', v_max_ts_date_p_interactor_session);			
+
+			raise notice 'I: %', v_sql;
+			execute v_sql;
+			
+			GET DIAGNOSTICS v_num_inserted = ROW_COUNT;
+			
+			return v_num_inserted;
+END;
+$$ LANGUAGE plpgsql;

--- a/tables/p_interactor_session.sql
+++ b/tables/p_interactor_session.sql
@@ -1,4 +1,4 @@
-CREATE TABLE p_interactor_session_agg_cpu_usage
+CREATE TABLE p_interactor_session
 (
 	vizql_session TEXT,
 	process_name TEXT,


### PR DESCRIPTION
... because its name was too long for the ODBC driver.
